### PR TITLE
Add support for specifying a commit message prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Download the relevant binary from [releases](https://github.com/form3tech-oss/te
 
 The following provider block variables are available for configuration:
 
+- `commit_message_prefix` - An optional prefix to be added to all commits generated as a result of manipulating the `CODEOWNERS` file.
 - `github_token` GitHub auth token - see below section. (read from env var `$GITHUB_TOKEN`)
 - `username` Username to use in commits (read from env var `$GITHUB_USERNAME`)
 - `email` Email to use in commits - this must match the email in your GPG key if you are signing commits (read from env var `$GITHUB_EMAIL`)

--- a/codeowners/provider.go
+++ b/codeowners/provider.go
@@ -12,6 +12,12 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
+			"commit_message_prefix": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "An optional prefix to be added to all commits generated as a result of manipulating the 'CODEOWNERS' file.",
+				DefaultFunc: schema.EnvDefaultFunc("COMMIT_MESSAGE_PREFIX", nil),
+			},
 			"github_token": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -56,11 +62,12 @@ func Provider() *schema.Provider {
 }
 
 type providerConfiguration struct {
-	client        *github.Client
-	ghUsername    string
-	ghEmail       string
-	gpgKey        string
-	gpgPassphrase string
+	commitMessagePrefix string
+	client              *github.Client
+	ghUsername          string
+	ghEmail             string
+	gpgKey              string
+	gpgPassphrase       string
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
@@ -72,10 +79,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	tc := oauth2.NewClient(ctx, ts)
 
 	return &providerConfiguration{
-		client:        github.NewClient(tc),
-		ghEmail:       d.Get("email").(string),
-		ghUsername:    d.Get("username").(string),
-		gpgKey:        d.Get("gpg_secret_key").(string),
-		gpgPassphrase: d.Get("gpg_passphrase").(string),
+		commitMessagePrefix: d.Get("commit_message_prefix").(string),
+		client:              github.NewClient(tc),
+		ghEmail:             d.Get("email").(string),
+		ghUsername:          d.Get("username").(string),
+		gpgKey:              d.Get("gpg_secret_key").(string),
+		gpgPassphrase:       d.Get("gpg_passphrase").(string),
 	}, nil
 }

--- a/codeowners/resource_file.go
+++ b/codeowners/resource_file.go
@@ -148,7 +148,7 @@ func resourceFileCreate(d *schema.ResourceData, m interface{}) error {
 		repoOwner:     file.RepositoryOwner,
 		repoName:      file.RepositoryName,
 		branch:        file.Branch,
-		commitMessage: "Adding CODEOWNERS file",
+		commitMessage: formatCommitMessage(config.commitMessagePrefix, "Adding CODEOWNERS file"),
 		gpgPassphrase: config.gpgPassphrase,
 		gpgPrivateKey: config.gpgKey,
 		username:      config.ghUsername,
@@ -180,7 +180,7 @@ func resourceFileUpdate(d *schema.ResourceData, m interface{}) error {
 		repoOwner:     file.RepositoryOwner,
 		repoName:      file.RepositoryName,
 		branch:        file.Branch,
-		commitMessage: "Updating CODEOWNERS file",
+		commitMessage: formatCommitMessage(config.commitMessagePrefix, "Updating CODEOWNERS file"),
 		gpgPassphrase: config.gpgPassphrase,
 		gpgPrivateKey: config.gpgKey,
 		username:      config.ghUsername,
@@ -210,7 +210,7 @@ func resourceFileDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	options := &github.RepositoryContentFileOptions{
-		Message: github.String("Removing CODEOWNERS file"),
+		Message: github.String(formatCommitMessage(config.commitMessagePrefix, "Removing CODEOWNERS file")),
 		SHA:     codeOwnerContent.SHA,
 	}
 	if file.Branch != "" {
@@ -296,4 +296,11 @@ func expandRuleset(in *schema.Set) Ruleset {
 		})
 	}
 	return out
+}
+
+func formatCommitMessage(p, m string) string {
+	if p == "" {
+		return m
+	}
+	return strings.TrimSpace(p) + " " + m
 }


### PR DESCRIPTION
This PR adds support for specifying a commit message prefix to be used in all commits made by the provider. This can be used, for example, to force CI to be skipped.