### PR TITLE
Add arm64 architecture to goreleaser.yml

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -6,6 +6,7 @@ builds:
       - CGO_ENABLED=0
     goarch:
       - amd64
+      - arm64
     goos:
       - darwin
       - linux


### PR DESCRIPTION
In order to eventually support Apple silicon we need to build our Terraform providers for `arm64`. 
This PR adds `arm64` as a target for `goreleaser` to build for