### PR TITLE
update goreleaser

### DIFF
--- a/scripts/goreleaser.sh
+++ b/scripts/goreleaser.sh
@@ -3,7 +3,7 @@ set -e
 
 TAR_FILE="/tmp/goreleaser.tar.gz"
 RELEASES_URL="https://github.com/goreleaser/goreleaser/releases"
-PINNED_VERSION="v0.173.2"
+PINNED_VERSION="v1.10.2"
 
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
 


### PR DESCRIPTION
A [bug](https://github.com/goreleaser/goreleaser/pull/2404) in `goreleaser` causes builds for `darwin arm64` to be excluded when using Go 1.17.x. 